### PR TITLE
Added missing using to NewsArticle

### DIFF
--- a/WarframeObjects/NewsArticle.cs
+++ b/WarframeObjects/NewsArticle.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using Newtonsoft.Json;
 
 namespace WarframeNET
 {


### PR DESCRIPTION
File uses JsonPropertyAttribute but doesn't include Newtonsoft.Json. This adds it in.