### PR TITLE
Fixed ID being a long instead of string

### DIFF
--- a/WarframeObjects/Earthcycle.cs
+++ b/WarframeObjects/Earthcycle.cs
@@ -4,7 +4,7 @@ namespace WarframeNET
 {
     public class EarthCycle
     {
-        public long id { get; set; }
+        public string id { get; set; }
         public DateTime expiry { get; set; }
         public bool isDay { get; set; }
         public string timeLeft { get; set; }


### PR DESCRIPTION
The endpoint has earthCycle.id as a string value, and Newtonsoft.Json can't parse it as a long.